### PR TITLE
No need to error out if the propery can't be found

### DIFF
--- a/src/DAV/SearchHandler.php
+++ b/src/DAV/SearchHandler.php
@@ -112,7 +112,7 @@ class SearchHandler {
 		}, $xml->orderBy);
 		$select = array_map(function ($propName) use ($allProps) {
 			if (!isset($allProps[$propName])) {
-				throw new BadRequest('requested property is not a valid property for this scope');
+				return;
 			}
 			$prop = $allProps[$propName];
 			if (!$prop->selectable) {
@@ -120,6 +120,7 @@ class SearchHandler {
 			}
 			return $prop;
 		}, $xml->select);
+		$select = array_filter($select);
 
 		$where = $this->transformOperator($xml->where, $allProps);
 


### PR DESCRIPTION
Just don't search for it if it is not allowed. But we can still
continue. Webdav will give a 404 if it can't be found later anyway.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>