### PR TITLE
Prevent "Undefined index: 0" for where condition

### DIFF
--- a/src/XML/Operator.php
+++ b/src/XML/Operator.php
@@ -68,7 +68,7 @@ class Operator implements XmlDeserializable {
 			if ($reader->nodeType === Reader::ELEMENT) {
 				$argument = $reader->parseCurrentElement();
 				if ($argument['name'] === '{DAV:}prop') {
-					$operator->arguments[] = $argument['value'][0];
+					$operator->arguments[] = $argument['value'][0] ?? '';
 				} else {
 					$operator->arguments[] = $argument['value'];
 				}

--- a/tests/SearchPluginTest.php
+++ b/tests/SearchPluginTest.php
@@ -491,4 +491,39 @@ class SearchPluginTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(400, $response->getStatus());
 	}
 
+    public function testSearchQueryInvalidWhereNoProp() {
+        $this->searchBackend->expects($this->any())
+            ->method('getArbiterPath')
+            ->willReturn('foo');
+
+        $plugin = new SearchPlugin($this->searchBackend);
+        $server = new Server();
+        $plugin->initialize($server);
+
+        $request = new Request('SEARCH', '/index.php/foo', [
+            'Content-Type' => 'text/xml'
+        ]);
+        $request->setBaseUrl('/index.php');
+        $request->setBody(fopen(__DIR__ . '/invalidwherenoprop.xml', 'r'));
+        $response = new Response();
+
+        $this->searchBackend->expects($this->any())
+            ->method('isValidScope')
+            ->willReturn(true);
+
+        $this->searchBackend->expects($this->never())
+            ->method('search');
+
+		$this->searchBackend->expects($this->any())
+			->method('getPropertyDefinitionsForScope')
+			->willReturn([
+				new SearchPropertyDefinition('{http://ns.nextcloud.com:}fileid', false, true, true, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
+				new SearchPropertyDefinition('{DAV:}getcontentlength', true, true, true, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
+			]);
+
+        $plugin->searchHandler($request, $response);
+
+        $this->assertEquals(400, $response->getStatus());
+    }
+
 }

--- a/tests/invalidwherenoprop.xml
+++ b/tests/invalidwherenoprop.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<d:searchrequest xmlns:d="DAV:" xmlns:oc="http://ns.nextcloud.com">
+    <d:basicsearch>
+        <d:select>
+            <d:prop>
+                <d:getcontentlength/>
+            </d:prop>
+        </d:select>
+        <d:from>
+            <d:scope>
+                <d:href>/container1/</d:href>
+                <d:depth>infinity</d:depth>
+            </d:scope>
+        </d:from>
+        <d:where>
+            <d:gt>
+                <d:prop />
+                <d:literal />
+            </d:gt>
+        </d:where>
+        <d:orderby>
+            <d:order>
+                <d:prop>
+                    <d:getcontentlength/>
+                </d:prop>
+                <d:ascending/>
+            </d:order>
+        </d:orderby>
+    </d:basicsearch>
+</d:searchrequest>


### PR DESCRIPTION
```
        <d:where>
            <d:gt>
                <d:prop />
                <d:literal />
            </d:gt>
        </d:where>
```

A where condition like above will run into "Undefined index: 0". Report: https://github.com/nextcloud/server/issues/17447