### PR TITLE
Load tests only on dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"SearchDAV\\": "src/",
+			"SearchDAV\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
 			"SearchDAV\\Test\\": "tests/"
 		}
 	}


### PR DESCRIPTION
Tried to update the dependency at nextcloud/3rdparty and noticed that the tests/ files are autoloaded. Not sure how @rullzer fixed it at https://github.com/nextcloud/3rdparty/pull/90 but adding tests/ to autoload-dev should prevent it.